### PR TITLE
Port to 1.12.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,36 +11,20 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
     }
 }
 
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-ext.configFile = file "build.properties"
-
-configFile.withReader {
-    def prop = new Properties()
-    prop.load(it)
-    project.ext.config = new ConfigSlurper().parse prop
-}
-
-def VersionBuild = 0
-if (System.getenv("BUILD_NUMBER") != null) {
-    def buildver = System.getenv("BUILD_NUMBER")
-    VersionBuild = "-${buildver}"
-}
-
-version = "${config.minecraft_version}-${config.mod_version}${VersionBuild}"
+version = "1.12.2-1.6.0"
 group = "foxie"
 archivesBaseName = "Calendar"
 
 minecraft {
-    version = config.minecraft_version + "-" + config.forge_version
+    version = "1.12.2-14.23.5.2768"
     runDir = "run"
-    mappings = config.mappings
-    replaceIn "foxie/calendar/Calendar.java"
-    replace "@VERSION@", "${config.mod_version}"
+    mappings = "snapshot_20170227"
 }
 
 repositories {
@@ -93,7 +77,7 @@ artifacts {
 }
 
 build.dependsOn deobfJar, apiJar
-
+/*
 // deployment
 configurations { deployerJars }
 dependencies { deployerJars "org.apache.maven.wagon:wagon-ssh:2.2" }
@@ -145,3 +129,4 @@ uploadArchives {
         }
     }
 }
+*/

--- a/src/main/java/foxie/calendar/api/DateTimeEvent.java
+++ b/src/main/java/foxie/calendar/api/DateTimeEvent.java
@@ -1,6 +1,5 @@
 package foxie.calendar.api;
 
-
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.eventhandler.Event;
 

--- a/src/main/resources/assets/calendar/lang/en_US.lang
+++ b/src/main/resources/assets/calendar/lang/en_US.lang
@@ -1,7 +1,0 @@
-commands.fixedtime.usage=/time set|add|list <morning|midday|evening|midnight|0-23999|hh mm>
-commands.date.usage=/date [list|set <day> [<month> [<year>]]]
-commands.date.listing=CalendarProvider provides these months:
-commands.date.nosuchday=There is no such day in a year!
-commands.season.usage=/season [list]
-commands.season.current=It is %s right now
-commands.season.listing=List of seasons:

--- a/src/main/resources/assets/calendar/lang/en_us.lang
+++ b/src/main/resources/assets/calendar/lang/en_us.lang
@@ -1,0 +1,7 @@
+commands.fixedtime.usage=/time set|add|list <morning|midday|evening|midnight|0-23999|hh mm>
+commands.date.usage=/date [list|set <day> [<month> [<year>]]]
+commands.date.listing=CalendarProvider provides these months:
+commands.date.nosuchday=There is no such day in a year!
+commands.season.usage=/season [list]
+commands.season.current=It is %s right now
+commands.season.listing=List of seasons:

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,7 @@
+{
+    "pack": {
+        "description": "examplemod resources",
+        "pack_format": 3,
+        "_comment": "A pack_format of 3 should be used starting with Minecraft 1.11. All resources, including language files, should be lowercase (eg: en_us.lang). A pack_format of 2 will load your mod resources with LegacyV2Adapter, which requires language files to have uppercase letters (eg: en_US.lang)."
+    }
+}


### PR DESCRIPTION
Seems that your Calendar API was slightly abandoned and no work done here since September 2017, so I made a port to 1.12.2. 

Some notes: 
This PR pushes changes to master branch, create one for 1.11.2 to avoid troubles. (but still saved in master branch in my fork).
This is port with disabled deployment in build.gradle, because old ones isn't working properly for me and causing lots of errors, mostly with "config" thing. (feel free to ask for changes in your gradle file, if you need)
Built with Forge 14.23.5.2768

If you do not want to push this port and upload it, can it be as unofficial port of Calendar API?
P.S. I'm slighty bad at English, so feel free to ask questions.